### PR TITLE
Add in some more sanity checks for auth initialisation

### DIFF
--- a/src/bluebridge-app.js
+++ b/src/bluebridge-app.js
@@ -95,8 +95,6 @@ Polymer({
     },
 
     _firebaseUidChanged: function (uid) {
-      let promise = null
-      
       // No point checking uid if firebase isn't even available
       // for us to check
       if (!this.firebaseStatusKnown) {


### PR DESCRIPTION
It may only be worth doing the "sign-in" anonymously when firebase is ready, instead of the uid change. What are your thoughts @frenchnz ?
